### PR TITLE
Add params to missions API for DateTime filtering

### DIFF
--- a/ArmaforcesMissionBot/Controllers/ApiController.cs
+++ b/ArmaforcesMissionBot/Controllers/ApiController.cs
@@ -19,10 +19,22 @@ namespace ArmaforcesMissionBot.Controllers
     {
         [HttpGet("missions")]
         public void Missions(bool includeArchive = false, uint ttl = 0)
+            => Missions(DateTime.MinValue, DateTime.MaxValue, includeArchive);
+        
+        [HttpGet("missions")]
+        public void Missions(DateTime earliestDateTime, bool includeArchive = false, uint ttl = 0)
+            => Missions(earliestDateTime, DateTime.MaxValue, includeArchive, ttl);
+        
+        [HttpGet("missions")]
+        public void Missions(DateTime earliestDateTime, DateTime latestDateTime, bool includeArchive = false, uint ttl = 0)
         {
             var missions = Program.GetMissions();
             JArray missionArray = new JArray();
-            foreach (var mission in missions.Missions.Where(x => x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing).Reverse())
+            foreach (var mission in missions.Missions
+                .Where(x => x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing)
+                .Where(x => x.Date >= earliestDateTime)
+                .Where(x => x.Date <= latestDateTime)
+                .Reverse())
             {
                 var objMission = new JObject();
                 objMission.Add("title", mission.Title);
@@ -42,7 +54,10 @@ namespace ArmaforcesMissionBot.Controllers
             if(includeArchive)
             {
                 var archiveMissions = Program.GetArchiveMissions();
-                foreach (var mission in archiveMissions.ArchiveMissions.AsEnumerable().Reverse())
+                foreach (var mission in archiveMissions.ArchiveMissions.AsEnumerable()
+                    .Where(x => x.Date >= earliestDateTime)
+                    .Where(x => x.Date <= latestDateTime)
+                    .Reverse())
                 {
                     var objMission = new JObject();
                     objMission.Add("title", mission.Title);

--- a/ArmaforcesMissionBot/Controllers/ApiController.cs
+++ b/ArmaforcesMissionBot/Controllers/ApiController.cs
@@ -22,18 +22,18 @@ namespace ArmaforcesMissionBot.Controllers
             => Missions(DateTime.MinValue, DateTime.MaxValue, includeArchive);
         
         [HttpGet("missions")]
-        public void Missions(DateTime earliestDateTime, bool includeArchive = false, uint ttl = 0)
-            => Missions(earliestDateTime, DateTime.MaxValue, includeArchive, ttl);
+        public void Missions(DateTime fromDateTime, bool includeArchive = false, uint ttl = 0)
+            => Missions(fromDateTime, DateTime.MaxValue, includeArchive, ttl);
         
         [HttpGet("missions")]
-        public void Missions(DateTime earliestDateTime, DateTime latestDateTime, bool includeArchive = false, uint ttl = 0)
+        public void Missions(DateTime fromDateTime, DateTime toDateTime, bool includeArchive = false, uint ttl = 0)
         {
             var missions = Program.GetMissions();
             JArray missionArray = new JArray();
             foreach (var mission in missions.Missions
                 .Where(x => x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing)
-                .Where(x => x.Date >= earliestDateTime)
-                .Where(x => x.Date <= latestDateTime)
+                .Where(x => x.Date >= fromDateTime)
+                .Where(x => x.Date <= toDateTime)
                 .Reverse())
             {
                 var objMission = new JObject();
@@ -55,8 +55,8 @@ namespace ArmaforcesMissionBot.Controllers
             {
                 var archiveMissions = Program.GetArchiveMissions();
                 foreach (var mission in archiveMissions.ArchiveMissions.AsEnumerable()
-                    .Where(x => x.Date >= earliestDateTime)
-                    .Where(x => x.Date <= latestDateTime)
+                    .Where(x => x.Date >= fromDateTime)
+                    .Where(x => x.Date <= toDateTime)
                     .Reverse())
                 {
                     var objMission = new JObject();

--- a/ArmaforcesMissionBot/Controllers/ApiController.cs
+++ b/ArmaforcesMissionBot/Controllers/ApiController.cs
@@ -25,11 +25,12 @@ namespace ArmaforcesMissionBot.Controllers
 
             var missions = Program.GetMissions();
             JArray missionArray = new JArray();
-            foreach (var mission in missions.Missions
+            var openMissionsEnumerable = missions.Missions
                 .Where(x => x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing)
                 .Where(x => x.Date >= fromDateTime)
                 .Where(x => x.Date <= toDateTime)
-                .Reverse())
+                .Reverse();
+            foreach (var mission in openMissionsEnumerable)
             {
                 var objMission = new JObject();
                 objMission.Add("title", mission.Title);
@@ -49,10 +50,11 @@ namespace ArmaforcesMissionBot.Controllers
             if(includeArchive)
             {
                 var archiveMissions = Program.GetArchiveMissions();
-                foreach (var mission in archiveMissions.ArchiveMissions.AsEnumerable()
+                var archiveMissionsEnumerable = archiveMissions.ArchiveMissions.AsEnumerable()
                     .Where(x => x.Date >= fromDateTime)
                     .Where(x => x.Date <= toDateTime)
-                    .Reverse())
+                    .Reverse();
+                foreach (var mission in archiveMissionsEnumerable)
                 {
                     var objMission = new JObject();
                     objMission.Add("title", mission.Title);

--- a/ArmaforcesMissionBot/Controllers/ApiController.cs
+++ b/ArmaforcesMissionBot/Controllers/ApiController.cs
@@ -18,16 +18,11 @@ namespace ArmaforcesMissionBot.Controllers
     public class ApiController : ControllerBase
     {
         [HttpGet("missions")]
-        public void Missions(bool includeArchive = false, uint ttl = 0)
-            => Missions(DateTime.MinValue, DateTime.MaxValue, includeArchive);
-        
-        [HttpGet("missions")]
-        public void Missions(DateTime fromDateTime, bool includeArchive = false, uint ttl = 0)
-            => Missions(fromDateTime, DateTime.MaxValue, includeArchive, ttl);
-        
-        [HttpGet("missions")]
-        public void Missions(DateTime fromDateTime, DateTime toDateTime, bool includeArchive = false, uint ttl = 0)
+        public void Missions(DateTime? fromDateTime = null, DateTime? toDateTime = null, bool includeArchive = false, uint ttl = 0)
         {
+            fromDateTime = fromDateTime ?? DateTime.MinValue;
+            toDateTime = toDateTime ?? DateTime.MaxValue;
+
             var missions = Program.GetMissions();
             JArray missionArray = new JArray();
             foreach (var mission in missions.Missions


### PR DESCRIPTION
When merged this PR will:
- add `fromDateTime` and `toDateTime` params for missions API

Can be called with `2020-08-11` and also `2020-08-11 08:00:00`. Probably variations of these without days/seconds etc. will also work somehow.