### PR TITLE
Include full day in `toDateTime` if time is unspecified

### DIFF
--- a/ArmaforcesMissionBot/Controllers/ApiController.cs
+++ b/ArmaforcesMissionBot/Controllers/ApiController.cs
@@ -23,6 +23,16 @@ namespace ArmaforcesMissionBot.Controllers
             fromDateTime = fromDateTime ?? DateTime.MinValue;
             toDateTime = toDateTime ?? DateTime.MaxValue;
 
+            toDateTime = toDateTime ==
+                         new DateTime(toDateTime.Value.Year, toDateTime.Value.Month, toDateTime.Value.Day, 0, 0, 0)
+                ? new DateTime(toDateTime.Value.Year,
+                    toDateTime.Value.Month,
+                    toDateTime.Value.Day,
+                    23,
+                    59,
+                    59)
+                : toDateTime;
+
             var missions = Program.GetMissions();
             JArray missionArray = new JArray();
             var openMissionsEnumerable = missions.Missions


### PR DESCRIPTION
When merged this PR will:
- Add 23:59:59 when `toDateTime` time is unspecified in missions API