### PR TITLE
Add kick command for recruiters

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -7,6 +7,7 @@ AF_SignupRole=
 AF_BotRole=
 AF_RecruiterRole=
 AF_RecruitRole=
+AF_KickImageUrl=
 AF_CreateMissionChannel=
 AF_PublicContemptChannel=
 AF_HallOfShameChannel=

--- a/ArmaforcesMissionBot/DataClasses/Config.cs
+++ b/ArmaforcesMissionBot/DataClasses/Config.cs
@@ -19,6 +19,7 @@ namespace ArmaforcesMissionBot.DataClasses
         public ulong BotRole { get; set; }
         public ulong RecruiterRole { get; set; }
         public ulong RecruitRole { get; set; }
+        public string KickImageUrl { get; set; }
         public ulong CreateMissionChannel { get; set; }
         public ulong PublicContemptChannel { get; set; }
         public ulong HallOfShameChannel { get; set; }

--- a/ArmaforcesMissionBot/Modules/Ranks.cs
+++ b/ArmaforcesMissionBot/Modules/Ranks.cs
@@ -46,5 +46,38 @@ namespace ArmaforcesMissionBot.Modules
 
             await Context.Message.DeleteAsync();
         }
+
+        [Command("wyrzuc")]
+        [Summary("Wyrzuca rekruta bądź randoma z Discorda.")]
+        [RequireRank(RanksEnum.Recruiter)]
+        public async Task Kick(IGuildUser user)
+        {
+            Console.WriteLine($"[{DateTime.Now.ToString()}] {Context.User.Username} called kick command");
+            var signupRole = Context.Guild.GetRole(_config.SignupRole);
+            var userRoleIds = user.RoleIds;
+            if (userRoleIds.All(x => x == _config.RecruitRole || x == _config.AFGuild))
+            {
+                var embedBuilder = new EmbedBuilder()
+                {
+                    ImageUrl = _config.KickImageUrl
+                };
+                var replyMessage =
+                    await ReplyAsync(
+                        $"{user.Mention} został pomyślnie wykopany z serwera przez {Context.User.Mention}.",
+                        embed: embedBuilder.Build());
+                await user.KickAsync("AFK");
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(5000);
+                    await replyMessage.ModifyAsync(x => x.Embed = null);
+                });
+            }
+            else
+            {
+                await ReplyAsync($"Nie możesz wyrzucić {user.Mention}, nie jest on rekrutem.");
+            }
+
+            await Context.Message.DeleteAsync();
+        }
     }
 }


### PR DESCRIPTION
When merged this PR will:
- Add `AF!wyrzuc` (kick) command for recruiters, working only on users without ranks or only with recruit rank.