### PR TITLE
Add info when no signups or slots are available

### DIFF
--- a/ArmaforcesMissionBot/Features/RichPresence/GameStatusUpdater.cs
+++ b/ArmaforcesMissionBot/Features/RichPresence/GameStatusUpdater.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Timers;
+using ArmaforcesMissionBot.DataClasses;
+using ArmaforcesMissionBotSharedClasses;
+using Discord;
+using Discord.WebSocket;
+
+namespace ArmaforcesMissionBot.Features.RichPresence {
+    /// <summary>
+    /// Handles updating activity bar with signups data.
+    /// </summary>
+    public class GameStatusUpdater {
+        private readonly DiscordSocketClient _discordSocketClient;
+        private readonly SignupsData _signupsData;
+
+        private Timer _timer;
+        private int _statusCounter;
+        private Game _currentStatus;
+
+        public GameStatusUpdater(
+            DiscordSocketClient discordSocketClient,
+            SignupsData signupsData
+        ) {
+            _signupsData = signupsData;
+            _discordSocketClient = discordSocketClient;
+        }
+
+        public void StartTimer() {
+            _timer?.Dispose();
+            _timer = new Timer {Interval = 5000};
+
+            _timer.Elapsed += UpdateStatus;
+            _timer.AutoReset = true;
+            _timer.Enabled = true;
+        }
+
+        private void UpdateStatus(object sender, ElapsedEventArgs e)
+        {
+            var missionsWithSignups = _signupsData.Missions
+                .Where(x => x.Editing == Mission.EditEnum.NotEditing)
+                .ToList();
+            var missionsWithFreeSlots = missionsWithSignups
+                .Where(mission => Helpers.MiscHelper.CountFreeSlots(mission) != 0)
+                .ToList();
+            var signupsCount = missionsWithSignups.Count;
+            var missionsWithFreeSlotsCount = missionsWithFreeSlots.Count;
+
+            Game status;
+            if (signupsCount == 0)
+                status = CreateNoSignupsDetails();
+            else if (missionsWithFreeSlotsCount == 0)
+                status = CreateSignupsNoFreeSlotsDetails(missionsWithFreeSlotsCount, signupsCount);
+            else if (_statusCounter < missionsWithFreeSlotsCount)
+                status = CreateMissionSignupDetails(missionsWithFreeSlots.ElementAt(_statusCounter));
+            else
+                status = CreateSignupsCounterDetails(missionsWithFreeSlotsCount, signupsCount);
+
+            _statusCounter = AdjustCounter(missionsWithFreeSlotsCount);
+
+            if (status != _currentStatus)
+                _discordSocketClient.SetActivityAsync(_currentStatus);
+        }
+
+        private int AdjustCounter(int missionsWithFreeSlotsCount) 
+            => _statusCounter >= missionsWithFreeSlotsCount
+                ? 0
+                : _statusCounter++;
+
+        private static Game CreateSignupsNoFreeSlotsDetails(int freeSlots, int allSignups) 
+            => new Game($"Brak miejsc w zapisach. {freeSlots}/{allSignups}");
+
+        private static Game CreateNoSignupsDetails() 
+            => new Game($"Brak prowadzonych zapisów.");
+
+        private static Game CreateMissionSignupDetails(Mission mission) 
+            => new Game($"Miejsc: {Helpers.MiscHelper.CountFreeSlots(mission)}/{Helpers.MiscHelper.CountAllSlots(mission)} - {mission.Title}");
+
+        private static Game CreateSignupsCounterDetails(int freeSlots, int allSignups) 
+            => new Game($"Zapisy: {freeSlots}/{allSignups}");
+    }
+}

--- a/ArmaforcesMissionBot/Features/RichPresence/GameStatusUpdater.cs
+++ b/ArmaforcesMissionBot/Features/RichPresence/GameStatusUpdater.cs
@@ -60,8 +60,10 @@ namespace ArmaforcesMissionBot.Features.RichPresence {
 
             _statusCounter = AdjustCounter(missionsWithFreeSlotsCount);
 
-            if (status != _currentStatus)
-                _discordSocketClient.SetActivityAsync(_currentStatus);
+            if (status.Name == _currentStatus?.Name) return;
+
+            _currentStatus = status;
+            _discordSocketClient.SetActivityAsync(_currentStatus);
         }
 
         private int AdjustCounter(int missionsWithFreeSlotsCount) 

--- a/ArmaforcesMissionBot/Program.cs
+++ b/ArmaforcesMissionBot/Program.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Timers;
+using ArmaforcesMissionBot.Features.RichPresence;
 
 namespace ArmaforcesMissionBot
 {
@@ -23,8 +23,6 @@ namespace ArmaforcesMissionBot
         private IServiceProvider    _services;
         private List<IInstallable>  _handlers;
         private Config              _config;
-        private Timer               _timer;
-        private int                 _statusCounter;
         private static Program _instance;
         private static bool _botStarted;
 
@@ -106,12 +104,7 @@ namespace ArmaforcesMissionBot
             await _client.LoginAsync(TokenType.Bot, _config.DiscordToken);
             await _client.StartAsync();
 
-            _timer = new Timer();
-            _timer.Interval = 5000;
-
-            _timer.Elapsed += UpdateStatus;
-            _timer.AutoReset = true;
-            _timer.Enabled = true;
+            _services.GetService<GameStatusUpdater>().StartTimer();
 
             WebHost.CreateDefaultBuilder(args)
                 .UseUrls("http://*:5555")
@@ -123,34 +116,13 @@ namespace ArmaforcesMissionBot
             await Task.Delay(-1);
         }
 
-        private void UpdateStatus(object sender, ElapsedEventArgs e)
-        {
-            var signups = _services.GetService<SignupsData>();
-            Game status;
-            if (_statusCounter < signups.Missions.Where(x => x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing).Count())
-            {
-                var mission = signups.Missions.Where(x => x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing).ElementAt(_statusCounter);
-                status = new Game($"Miejsc: {Helpers.MiscHelper.CountFreeSlots(mission)}/{Helpers.MiscHelper.CountAllSlots(mission)} - {mission.Title}");
-            }
-            else
-            {
-                status = new Game($"Prowadzone zapisy: {signups.Missions.Where(x => x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing).Count()}");
-            }
-
-            if (_statusCounter >= signups.Missions.Where(x => x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing).Count())
-                _statusCounter = 0;
-            else
-                _statusCounter++;
-
-            _client.SetActivityAsync(status);
-        }
-
         public IServiceProvider BuildServiceProvider() => new ServiceCollection()
         .AddSingleton(_client)
         .AddSingleton<SignupsData>()
         .AddSingleton(_config)
         .AddSingleton<OpenedDialogs>()
         .AddSingleton<MissionsArchiveData>()
+        .AddSingleton<GameStatusUpdater>()
         .BuildServiceProvider();
 
         private async Task Load(SocketGuild guild)


### PR DESCRIPTION
When merged will:
- Extract this damn thing out of `Program.cs`.
- Add information that there are no signups available.
- Add information that no signups have free slots available.
- Add information how many active signups have slots available.

![obraz](https://user-images.githubusercontent.com/30000580/96458699-859fdf80-1221-11eb-9d25-b3bc104fe5c5.png)