### PR TITLE
Prevent emoji duplication in mission singup

### DIFF
--- a/ArmaforcesMissionBot/Modules/Signups.cs
+++ b/ArmaforcesMissionBot/Modules/Signups.cs
@@ -282,13 +282,12 @@ namespace ArmaforcesMissionBot.Modules
                         }
                     }
                     
-                    foreach (var slotEmoji in team.Slots)
+                   if (team.Slots
+                        .GroupBy(x => x.Emoji)
+                        .Any(x => x.Count() > 1))
                     {
-                        if (team.Slots.FindAll(x => x.Emoji == slotEmoji.Emoji).Count > 1)
-                        {
-                            await ReplyAsync("Zdublowałeś reakcje. Poprawiaj to!");
-                            return;
-                        }
+                        await ReplyAsync("Zdublowałeś reakcje. Poprawiaj to!");
+                        return;
                     }
 
                     var embed = new EmbedBuilder()

--- a/ArmaforcesMissionBot/Modules/Signups.cs
+++ b/ArmaforcesMissionBot/Modules/Signups.cs
@@ -281,6 +281,15 @@ namespace ArmaforcesMissionBot.Modules
                             team.Pattern += $"{slot.Emoji} [{slot.Count}] {slot.Name} ";
                         }
                     }
+                    
+                    foreach (var slotEmoji in team.Slots)
+                    {
+                        if (team.Slots.FindAll(x => x.Emoji == slotEmoji.Emoji).Count > 1)
+                        {
+                            await ReplyAsync("Zdublowałeś reakcje. Poprawiaj to!");
+                            return;
+                        }
+                    }
 
                     var embed = new EmbedBuilder()
                         .WithColor(Color.Green)


### PR DESCRIPTION
It was possible to create a team where slots have the same reactions. The change prevents user from doing that.