### PR TITLE
New way of signup owner identification

### DIFF
--- a/ArmaforcesMissionBot/DataClasses/BotConstants.cs
+++ b/ArmaforcesMissionBot/DataClasses/BotConstants.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ArmaforcesMissionBot.DataClasses
+{
+    public class BotConstants
+    {
+        public const string DISCORD_USER_URL_PREFIX = "https://discord.com/users/"; 
+
+    }
+}

--- a/ArmaforcesMissionBot/Handlers/ArchiveHandler.cs
+++ b/ArmaforcesMissionBot/Handlers/ArchiveHandler.cs
@@ -59,6 +59,8 @@ namespace ArmaforcesMissionBot.Handlers
                             .AddField("Zamknięcie zapisów:", mission.CloseTime.ToString())
                             .WithAuthor(_client.GetUser(mission.Owner).Username)
                             .AddField("Modlista:", mission.Modlist);
+							
+						archiveEmbed.Author.Url = BotConstants.DISCORD_USER_URL_PREFIX + (mission.Owner).ToString();	
 
                         if (mission.Attachment != null)
                             archiveEmbed.WithImageUrl(mission.Attachment);

--- a/ArmaforcesMissionBot/Handlers/ArchiveHandler.cs
+++ b/ArmaforcesMissionBot/Handlers/ArchiveHandler.cs
@@ -57,10 +57,8 @@ namespace ArmaforcesMissionBot.Handlers
                             .WithFooter(mission.Date.ToString())
                             .AddField("Data:", mission.Date)
                             .AddField("Zamknięcie zapisów:", mission.CloseTime.ToString())
-                            .WithAuthor(_client.GetUser(mission.Owner).Username)
+                            .WithAuthor(_client.GetUser(mission.Owner).Username, url: BotConstants.DISCORD_USER_URL_PREFIX + (mission.Owner).ToString())
                             .AddField("Modlista:", mission.Modlist);
-							
-						archiveEmbed.Author.Url = BotConstants.DISCORD_USER_URL_PREFIX + (mission.Owner).ToString();	
 
                         if (mission.Attachment != null)
                             archiveEmbed.WithImageUrl(mission.Attachment);

--- a/ArmaforcesMissionBot/Handlers/LoadupHandler.cs
+++ b/ArmaforcesMissionBot/Handlers/LoadupHandler.cs
@@ -146,8 +146,7 @@ namespace ArmaforcesMissionBot.Handlers
 					{
 						mission.Title = embed.Title;
                         mission.Description = embed.Description;
-                        var user = embed.Author.Value.Name.Split("#");
-                        mission.Owner = _client.GetUser(user[0], user[1]).Id;
+                        mission.Owner = ulong.Parse(embed.Author.Value.Url.Substring(26));
                         // Do I need author id again?
                         mission.Attachment = embed.Image.HasValue ? embed.Image.Value.Url : null;
                         foreach (var field in embed.Fields)

--- a/ArmaforcesMissionBot/Handlers/LoadupHandler.cs
+++ b/ArmaforcesMissionBot/Handlers/LoadupHandler.cs
@@ -146,7 +146,7 @@ namespace ArmaforcesMissionBot.Handlers
 					{
 						mission.Title = embed.Title;
                         mission.Description = embed.Description;
-                        mission.Owner = ulong.Parse(embed.Author.Value.Url.Substring(26));
+                        mission.Owner = ulong.Parse(embed.Author.Value.Url.Substring(BotConstants.DISCORD_USER_URL_PREFIX.Length));
                         // Do I need author id again?
                         mission.Attachment = embed.Image.HasValue ? embed.Image.Value.Url : null;
                         foreach (var field in embed.Fields)

--- a/ArmaforcesMissionBot/Helpers/SignupHelper.cs
+++ b/ArmaforcesMissionBot/Helpers/SignupHelper.cs
@@ -172,7 +172,7 @@ namespace ArmaforcesMissionBot.Helpers
                     .AddField("Zamknięcie zapisów:", mission.CloseTime.ToString())
                     .WithAuthor(guild.GetUser(mission.Owner));
 
-            mainEmbed.Author.Url = "https://discord.com/users/" + (mission.Owner).ToString();
+            mainEmbed.Author.Url = BotConstants.DISCORD_USER_URL_PREFIX + (mission.Owner).ToString();
             
             if (mission.Attachment != null)
                 mainEmbed.WithImageUrl(mission.Attachment);

--- a/ArmaforcesMissionBot/Helpers/SignupHelper.cs
+++ b/ArmaforcesMissionBot/Helpers/SignupHelper.cs
@@ -172,6 +172,8 @@ namespace ArmaforcesMissionBot.Helpers
                     .AddField("Zamknięcie zapisów:", mission.CloseTime.ToString())
                     .WithAuthor(guild.GetUser(mission.Owner));
 
+            mainEmbed.Author.Url = "https://discord.com/users/" + (mission.Owner).ToString();
+            
             if (mission.Attachment != null)
                 mainEmbed.WithImageUrl(mission.Attachment);
 


### PR DESCRIPTION
Fix adds URL with ID behind Nickname in signups. Bot now checks ID in URL to determine owner. Prevents problems when owner changes Nickname. 

NOTE: All current signups will not be recognized by new version and not operable. Fix should be downloaded when there are no active signups or they have to be recreated after changes. 