### PR TITLE
New command for changing signups name

### DIFF
--- a/ArmaforcesMissionBot/Handlers/SignupHandler.cs
+++ b/ArmaforcesMissionBot/Handlers/SignupHandler.cs
@@ -200,7 +200,9 @@ namespace ArmaforcesMissionBot.Handlers
         {
             var signups = _services.GetService<SignupsData>();
 
-            if (signups.Missions.Any(x => x.SignupChannel == channel.Id))
+            if (signups.Missions.Any(x =>
+                x.SignupChannel == channel.Id &&
+                (x.Editing != ArmaforcesMissionBotSharedClasses.Mission.EditEnum.New)))
             {
                 signups.Missions.RemoveAll(x => x.SignupChannel == channel.Id);
             }

--- a/ArmaforcesMissionBot/Handlers/SignupHandler.cs
+++ b/ArmaforcesMissionBot/Handlers/SignupHandler.cs
@@ -200,9 +200,7 @@ namespace ArmaforcesMissionBot.Handlers
         {
             var signups = _services.GetService<SignupsData>();
 
-            if (signups.Missions.Any(x =>
-                x.SignupChannel == channel.Id &&
-                (x.Editing != ArmaforcesMissionBotSharedClasses.Mission.EditEnum.New)))
+            if (signups.Missions.Any(x => x.SignupChannel == channel.Id))
             {
                 signups.Missions.RemoveAll(x => x.SignupChannel == channel.Id);
             }

--- a/ArmaforcesMissionBot/Helpers/SignupHelper.cs
+++ b/ArmaforcesMissionBot/Helpers/SignupHelper.cs
@@ -280,6 +280,7 @@ namespace ArmaforcesMissionBot.Helpers
                 // really hacky solution to avoid recalculating indexes for each channel integer should have 
                 // space for around 68 years, and this bot is not going to work this long for sure
                 x.Position = index;
+                x.Name = mission.Title;
             });
 
             var mainEmbed = await CreateMainEmbed(guild, mission);

--- a/ArmaforcesMissionBot/Modules/Signups.cs
+++ b/ArmaforcesMissionBot/Modules/Signups.cs
@@ -690,13 +690,11 @@ namespace ArmaforcesMissionBot.Modules
         [ContextDMOrChannel]
         public async Task MissionName([Remainder] string newTitle)
         {
-            var signups = _map.GetService<SignupsData>();
-
-            if (signups.Missions.Any(x =>
+            if (SignupsData.Missions.Any(x =>
                 (x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started) &&
                 x.Owner == Context.User.Id))
             {
-                var mission = signups.Missions.Single(x =>
+                var mission = SignupsData.Missions.Single(x =>
                 (x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started) &&
                 x.Owner == Context.User.Id);
 

--- a/ArmaforcesMissionBot/Modules/Signups.cs
+++ b/ArmaforcesMissionBot/Modules/Signups.cs
@@ -701,52 +701,8 @@ namespace ArmaforcesMissionBot.Modules
                 x.Owner == Context.User.Id);
 
                 mission.Title = newTitle;
-                mission.MentionEveryone = false;
 
-                var embed = new EmbedBuilder()
-                    .WithColor(Color.Green)
-                    .WithTitle(mission.Title)
-                    .WithDescription(mission.Description)
-                    .WithFooter(mission.Date.ToString())
-                    .AddField("Zamknięcie zapisów:", mission.CloseTime.ToString())
-                    .AddField("Wołanie wszystkich:", mission.MentionEveryone)
-                    .WithAuthor(Context.User);
-
-                if (mission.Attachment != null)
-                    embed.WithImageUrl(mission.Attachment);
-
-                embed.AddField("Modlista:", mission.Modlist);
-
-                _miscHelper.BuildTeamsEmbed(mission.Teams, embed);
-
-                _miscHelper.CreateConfirmationDialog(
-                        _dialogs,
-                       Context,
-                       embed.Build(),
-                       (Dialog dialog) =>
-                       {
-                           _dialogs.Dialogs.Remove(dialog);
-                           mission.Editing = ArmaforcesMissionBotSharedClasses.Mission.EditEnum.New;
-                           _ = SignupHelper.CreateSignupChannel(signups, Context.User.Id, Context.Channel);
-                           ReplyAsync("Pa na to!");
-
-                           try
-                           {
-                               var guild = _client.GetGuild(_config.AFGuild);
-                               guild.GetTextChannel(mission.SignupChannel).DeleteAsync();
-                           }
-                           catch
-                           {
-                               ReplyAsync("Nie mogłem usunąć starego kanału zapisów.");
-                           }
-                       },
-                       (Dialog dialog) =>
-                       {
-                           Context.Channel.DeleteMessageAsync(dialog.DialogID);
-                           _dialogs.Dialogs.Remove(dialog);
-                           ReplyAsync("Co Ci znowu nie pasuje?");
-                       });
-
+                await ReplyAsync("Niech będzie...");
             }
             else
             {


### PR DESCRIPTION
Added command. Function active after choosing mission to edit. Then it basically creates new signups and deletes the old one without mentioning everyone. 