### PR TITLE
Fix preventing starting multiple signups edit

### DIFF
--- a/ArmaforcesMissionBot/Extensions/SignupsDataExtensions.cs
+++ b/ArmaforcesMissionBot/Extensions/SignupsDataExtensions.cs
@@ -1,0 +1,20 @@
+﻿using ArmaforcesMissionBot.DataClasses;
+using ArmaforcesMissionBotSharedClasses;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ArmaforcesMissionBot.Extensions
+{
+    public static class SignupsDataExtensions
+    {
+        public static Mission GetCurrentlyEditedMission(this SignupsData signupsData, ulong userId)
+        {
+            return signupsData.Missions.SingleOrDefault(x =>
+                x.Owner == userId &&
+                ((x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.New) ||
+                (x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started)));
+        }
+    }
+}

--- a/ArmaforcesMissionBot/Helpers/SignupHelper.cs
+++ b/ArmaforcesMissionBot/Helpers/SignupHelper.cs
@@ -344,15 +344,5 @@ namespace ArmaforcesMissionBot.Helpers
                 await channnel.SendMessageAsync("A może byś mi najpierw powiedział co ty chcesz potwierdzić?");
             }
         }
-
-        public Mission GetCurrentlyEditedMission(ulong userId, SignupsData signups)
-        {
-            var currentlyEditedMission = signups.Missions.Find(x => 
-                x.Owner == userId && 
-                ((x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.New) ||
-                (x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started)));
-
-            return currentlyEditedMission;
-        }
     }
 }

--- a/ArmaforcesMissionBot/Helpers/SignupHelper.cs
+++ b/ArmaforcesMissionBot/Helpers/SignupHelper.cs
@@ -344,5 +344,15 @@ namespace ArmaforcesMissionBot.Helpers
                 await channnel.SendMessageAsync("A może byś mi najpierw powiedział co ty chcesz potwierdzić?");
             }
         }
+
+        public Mission GetCurrentlyEditedMission(ulong userId, SignupsData signups)
+        {
+            var currentlyEditedMission = signups.Missions.Find(x => 
+                x.Owner == userId && 
+                ((x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.New) ||
+                (x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started)));
+
+            return currentlyEditedMission;
+        }
     }
 }

--- a/ArmaforcesMissionBot/Modules/Signups.cs
+++ b/ArmaforcesMissionBot/Modules/Signups.cs
@@ -668,20 +668,20 @@ namespace ArmaforcesMissionBot.Modules
         [ContextDMOrChannel]
         public async Task EditMission(int missionNo)
         {
-            var signups = _map.GetService<SignupsData>();
-
-            int index = 0;
-
-            foreach (var mission in signups.Missions.Where(x => x.Owner == Context.User.Id && x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing))
+           if (SignupHelper.GetCurrentlyEditedMission(Context.User.Id, SignupsData) == null)
             {
-                if (index++ == missionNo)
-                {
-                    // Don't want to write another function just to copy class, and performance isn't a problem here so just serialize it and deserialize
-                    var serialized = JsonConvert.SerializeObject(mission);
-                    signups.BeforeEditMissions[Context.User.Id] = JsonConvert.DeserializeObject<ArmaforcesMissionBotSharedClasses.Mission>(serialized);
-                    mission.Editing = ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started;
-                    await ReplyAsync("Luzik, co chcesz zmienić?");
-                }
+                var userMissions = SignupsData.Missions.FindAll(x => x.Owner == Context.User.Id && x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.NotEditing);
+                var editMission = userMissions[missionNo];
+
+                // Don't want to write another function just to copy class, and performance isn't a problem here so just serialize it and deserialize
+                var serialized = JsonConvert.SerializeObject(editMission);
+                SignupsData.BeforeEditMissions[Context.User.Id] = JsonConvert.DeserializeObject<ArmaforcesMissionBotSharedClasses.Mission>(serialized);
+                editMission.Editing = ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started;
+                await ReplyAsync("Luzik, co chcesz zmienić?");
+            }
+            else
+            {
+                await ReplyAsync("Hola hola, nie wszystko naraz. Skończ poprzednią edycję.");
             }
         }
 


### PR DESCRIPTION
It is possible to start signups edit many times for different signups. 
Additional method for checking currently edited or created mission by user. Can be implemented in the most of the methods regarding creating signups. 