### PR TITLE
Modlist link in signups fix

### DIFF
--- a/ArmaforcesMissionBot/Features/Modsets/ModsetProvider.cs
+++ b/ArmaforcesMissionBot/Features/Modsets/ModsetProvider.cs
@@ -23,7 +23,7 @@ namespace ArmaforcesMissionBot.Features.Modsets
         public string GetModsetNameFromUrl(string modsetNameOrUrl)
         {
             return modsetNameOrUrl.Contains('/')
-                ? modsetNameOrUrl.Split('/').Reverse().ElementAt(1)
+                ? modsetNameOrUrl.Split('/').Last()
                 : modsetNameOrUrl;
         }
 

--- a/ArmaforcesMissionBot/Modules/Signups.cs
+++ b/ArmaforcesMissionBot/Modules/Signups.cs
@@ -159,9 +159,9 @@ namespace ArmaforcesMissionBot.Modules
                 await ModsetProvider.GetModsetDownloadUrl(modsetName).Match(
                         onSuccess: url =>
                         {
-                            mission.ModlistUrl = mission.Modlist = url;
+                            mission.ModlistUrl = mission.Modlist = url.Replace(" ", "%20");
                             mission.ModlistName = modsetName;
-                            return ReplyAsync($"Modset {modsetName} was found under {url}.");
+                            return ReplyAsync($"Modset {modsetName} was found under {mission.ModlistUrl}.");
                         },
                         onFailure: error => ReplyAsync(error));
             }


### PR DESCRIPTION
Fixed using links in creating signups.
Fixed broken links when there are spaces in modlist names.