### PR TITLE
Mission edit using its name

### DIFF
--- a/ArmaforcesMissionBot/Extensions/SignupsDataExtensions.cs
+++ b/ArmaforcesMissionBot/Extensions/SignupsDataExtensions.cs
@@ -1,0 +1,20 @@
+﻿using ArmaforcesMissionBot.DataClasses;
+using ArmaforcesMissionBotSharedClasses;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ArmaforcesMissionBot.Extensions
+{
+    public static class SignupsDataExtensions
+    {
+        public static Mission GetCurrentlyEditedMission(this SignupsData signupsData, ulong userId)
+        {
+            return signupsData.Missions.SingleOrDefault(x =>
+                x.Owner == userId &&
+                ((x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.New) ||
+                (x.Editing == ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started)));
+        }
+    }
+}

--- a/ArmaforcesMissionBot/Modules/Signups.cs
+++ b/ArmaforcesMissionBot/Modules/Signups.cs
@@ -657,6 +657,40 @@ namespace ArmaforcesMissionBot.Modules
                 }
             }
         }
+		
+        [Command("edytuj-misje")]
+        [Summary("Po podaniu nazwy misji jako parametru włączy edycje danej misji (część bez zespołów).")]
+        [ContextDMOrChannel]
+        public async Task EditMission([Remainder] string title)
+        {
+            var currentlyEditedMission = SignupsData.GetCurrentlyEditedMission(Context.User.Id);
+
+            if (currentlyEditedMission == null)
+            {
+                var missionToBeEdited = SignupsData.Missions.FirstOrDefault(x => x.Title == title);
+                if (missionToBeEdited == null)
+                {
+                    await ReplyAsync($"Nie ma misji o takiej nazwie.");
+                    return;
+                }    
+                
+                if (missionToBeEdited.Owner != Context.User.Id)
+                {
+                    await ReplyAsync($"Nie nauczyli żeby nie ruszać nie swojego?");
+                    return;
+                }
+
+                // Don't want to write another function just to copy class, and performance isn't a problem here so just serialize it and deserialize
+                var serialized = JsonConvert.SerializeObject(missionToBeEdited);
+                SignupsData.BeforeEditMissions[Context.User.Id] = JsonConvert.DeserializeObject<ArmaforcesMissionBotSharedClasses.Mission>(serialized);
+                missionToBeEdited.Editing = ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started;
+                await ReplyAsync($"A więc `{missionToBeEdited.Title}`. Co chcesz zmienić?");
+            }
+            else
+            {
+                await ReplyAsync($"Hola hola, nie wszystko naraz. Skończ edytować `{currentlyEditedMission.Title}`.");
+            }
+        }
 
         [Command("edytuj-nazwe-misji")]
         [Summary("Edycja nazwy już utworzonej misji.")]

--- a/ArmaforcesMissionBot/Modules/Signups.cs
+++ b/ArmaforcesMissionBot/Modules/Signups.cs
@@ -639,35 +639,15 @@ namespace ArmaforcesMissionBot.Modules
         }
 
         [Command("edytuj-misje")]
-        [Summary("Po podaniu indeksu misji jako parametru włączy edycje danej misji (część bez zespołów).")]
+        [Summary("Po użyciu #wzmianki kanału misji jako parametru włączy edycje danej misji (część bez zespołów).")]
         [ContextDMOrChannel]
-        public async Task EditMission(int missionNo)
-        {
-            int index = 0;
-
-            foreach (var mission in SignupsData.Missions.Where(x => x.Owner == Context.User.Id && x.Editing == Mission.EditEnum.NotEditing))
-            {
-                if (index++ == missionNo)
-                {
-                    // Don't want to write another function just to copy class, and performance isn't a problem here so just serialize it and deserialize
-                    var serialized = JsonConvert.SerializeObject(mission);
-                    SignupsData.BeforeEditMissions[Context.User.Id] = JsonConvert.DeserializeObject<Mission>(serialized);
-                    mission.Editing = Mission.EditEnum.Started;
-                    await ReplyAsync("Luzik, co chcesz zmienić?");
-                }
-            }
-        }
-		
-        [Command("edytuj-misje")]
-        [Summary("Po podaniu nazwy misji jako parametru włączy edycje danej misji (część bez zespołów).")]
-        [ContextDMOrChannel]
-        public async Task EditMission([Remainder] string title)
+        public async Task EditMission(IGuildChannel channel)
         {
             var currentlyEditedMission = SignupsData.GetCurrentlyEditedMission(Context.User.Id);
 
             if (currentlyEditedMission == null)
             {
-                var missionToBeEdited = SignupsData.Missions.FirstOrDefault(x => x.Title == title);
+                var missionToBeEdited = SignupsData.Missions.FirstOrDefault(x => x.SignupChannel == channel.Id);
                 if (missionToBeEdited == null)
                 {
                     await ReplyAsync($"Nie ma misji o takiej nazwie.");
@@ -680,9 +660,6 @@ namespace ArmaforcesMissionBot.Modules
                     return;
                 }
 
-                // Don't want to write another function just to copy class, and performance isn't a problem here so just serialize it and deserialize
-                var serialized = JsonConvert.SerializeObject(missionToBeEdited);
-                SignupsData.BeforeEditMissions[Context.User.Id] = JsonConvert.DeserializeObject<ArmaforcesMissionBotSharedClasses.Mission>(serialized);
                 missionToBeEdited.Editing = ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started;
                 await ReplyAsync($"A więc `{missionToBeEdited.Title}`. Co chcesz zmienić?");
             }

--- a/ArmaforcesMissionBot/Modules/Signups.cs
+++ b/ArmaforcesMissionBot/Modules/Signups.cs
@@ -640,6 +640,8 @@ namespace ArmaforcesMissionBot.Modules
                     return;
                 }
 
+                var serialized = JsonConvert.SerializeObject(missionToBeEdited);
+                SignupsData.BeforeEditMissions[Context.User.Id] = JsonConvert.DeserializeObject<ArmaforcesMissionBotSharedClasses.Mission>(serialized);
                 missionToBeEdited.Editing = ArmaforcesMissionBotSharedClasses.Mission.EditEnum.Started;
                 await ReplyAsync($"A więc `{missionToBeEdited.Title}`. Co chcesz zmienić?");
             }


### PR DESCRIPTION
New feature to start editing mission using its name instead of index.

Able to merge after PR #31 