### PR TITLE
Add current mission API endpoint

### DIFF
--- a/ArmaforcesMissionBot/Controllers/ApiController.cs
+++ b/ArmaforcesMissionBot/Controllers/ApiController.cs
@@ -41,6 +41,18 @@ namespace ArmaforcesMissionBot.Controllers
             _miscHelper = miscHelper;
         }
 
+        [HttpGet("currentMission")]
+        public IActionResult CurrentMission()
+        {
+            var mission = _signupsData.Missions
+                .Concat(_missionsArchiveData.ArchiveMissions.Cast<IMission>())
+                .Where(mission => mission.Date < DateTime.Now && mission.Date.AddHours(3) > DateTime.Now)
+                .OrderBy(mission => mission.Date)
+                .FirstOrDefault();
+
+            return Ok(mission);
+        }
+
         [HttpGet("missions")]
         public void Missions(DateTime? fromDateTime = null, DateTime? toDateTime = null, bool includeArchive = false, uint ttl = 0)
         {

--- a/ArmaforcesMissionBot/Controllers/ApiController.cs
+++ b/ArmaforcesMissionBot/Controllers/ApiController.cs
@@ -50,7 +50,9 @@ namespace ArmaforcesMissionBot.Controllers
                 .OrderBy(mission => mission.Date)
                 .FirstOrDefault();
 
-            return Ok(mission);
+            return mission is null
+                ? (IActionResult) NotFound("No ongoing mission.")
+                : Ok(mission);
         }
 
         [HttpGet("missions")]

--- a/ArmaforcesMissionBot/DataClasses/MissionsArchiveData.cs
+++ b/ArmaforcesMissionBot/DataClasses/MissionsArchiveData.cs
@@ -2,23 +2,24 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using ArmaforcesMissionBotSharedClasses;
 
 namespace ArmaforcesMissionBot.DataClasses
 {
     public class MissionsArchiveData
     {
-        public class Mission
+        public class Mission : IMission
         {
-            public string Title;
-            public DateTime Date;
-            public DateTime? CloseTime = null;
-            public string Description;
-            public string Modlist;
+            public string Title { get; set; }
+            public DateTime Date { get; set; }
+            public DateTime? CloseTime { get; set; } = null;
+            public string Description { get; set; }
+            public string Modlist { get; set; }
             public string ModlistUrl;
             public string ModlistName;
             public string Attachment;
-            public ulong FreeSlots;
-            public ulong AllSlots;
+            public ulong FreeSlots { get; set; }
+            public ulong AllSlots { get; set; }
         }
 
         public List<Mission> ArchiveMissions = new List<Mission>();

--- a/ArmaforcesMissionBot/Handlers/LoadupHandler.cs
+++ b/ArmaforcesMissionBot/Handlers/LoadupHandler.cs
@@ -381,16 +381,19 @@ namespace ArmaforcesMissionBot.Handlers
                 var newArchiveMission = new MissionsArchiveData.Mission();
 
                 newArchiveMission.Title = embed.Title;
+                DateTime date;
                 if (!DateTime.TryParseExact(
                     embed.Footer.Value.Text,
                     "dd.MM.yyyy HH:mm:ss",
                     CultureInfo.InvariantCulture,
                     DateTimeStyles.RoundtripKind,
-                    out newArchiveMission.Date))
+                    out date))
                 {
                     Console.WriteLine($"Loading failed on mission date: {embed.Footer.Value.Text}");
                     continue;
                 }
+
+                newArchiveMission.Date = date;
                 newArchiveMission.CloseTime = message.Timestamp.DateTime;
                 newArchiveMission.Description = embed.Description;
                 newArchiveMission.Attachment = embed.Image.HasValue ? embed.Image.Value.Url : null;

--- a/ArmaforcesMissionBotSharedClasses/IMission.cs
+++ b/ArmaforcesMissionBotSharedClasses/IMission.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace ArmaforcesMissionBotSharedClasses
+{
+    public interface IMission
+    {
+        string Title { get; }
+
+        DateTime Date { get; }
+
+        DateTime? CloseTime { get; }
+
+        string Description { get; }
+
+        string Modlist { get; }
+
+        ulong FreeSlots { get; }
+
+        ulong AllSlots { get; }
+    }
+}

--- a/ArmaforcesMissionBotSharedClasses/Mission.cs
+++ b/ArmaforcesMissionBotSharedClasses/Mission.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 namespace ArmaforcesMissionBotSharedClasses
 {
     [Serializable]
-    public class Mission
+    public class Mission : IMission
     {
         [Serializable]
         public enum EditEnum
@@ -53,16 +53,18 @@ namespace ArmaforcesMissionBotSharedClasses
             public ulong TeamMsg;
             public ulong Reserve = 0;
         }
-        public string Title;
-        public DateTime Date;
-        public DateTime? CloseTime = null;
-        public string Description;
+        public string Title { get; set; }
+        public DateTime Date { get; set; }
+        public DateTime? CloseTime { get; set; } = null;
+        public string Description { get; set; }
         public string Attachment;
         public byte[] AttachmentBytes;
         public string FileName;
-        public string Modlist;
+        public string Modlist { get; set; }
         public string ModlistUrl;
         public string ModlistName;
+        public ulong FreeSlots { get; set; }
+        public ulong AllSlots { get; set; }
         public List<Team> Teams = new List<Team>();
         public ulong Owner;
         public ulong SignupChannel;


### PR DESCRIPTION
Adds endpoint to retrieve current ongoing mission.

Mission is considered as ongoing from mission date for 3 h, e.g. for mission starting at 20:00 it will be returned as ongoing between 20:00 and 23:00. If few missions are within that timeframe only the earliest one is returned.

Returns 200 with current mission.
Returns 404 when there is no ongoing mission.

Closes #43 