### PR TITLE
Add aliases for startServer command

### DIFF
--- a/ArmaforcesMissionBot/Modules/Server.cs
+++ b/ArmaforcesMissionBot/Modules/Server.cs
@@ -20,9 +20,29 @@ namespace ArmaforcesMissionBot.Modules
         [Summary("Pozwala natychmiast uruchomić serwer z zadanym modsetem. Na przykład: AF!startServer default.")]
         [ContextDMOrChannel]
         public override Task StartServer(string modsetName) => base.StartServer(modsetName);
+        
+        [Command("startSerwer")]
+        [Summary("Alias dla `AF!startServer`.")]
+        [ContextDMOrChannel]
+        public Task StartSerwer(string modsetName) => StartServer(modsetName);
+        
+        [Command("serverStart")]
+        [Summary("Alias dla `AF!startServer`.")]
+        [ContextDMOrChannel]
+        public Task ServerStart(string modsetName) => StartServer(modsetName);
 
         [Summary("Pozwala uruchomić serwer z zadanym modsetem o zadanej godzinie w danym dniu. Na przykład: AF!startServer default 2020-07-17T19:00.")]
         [ContextDMOrChannel]
         public override Task StartServer(string modsetName, DateTime? dateTime) => base.StartServer(modsetName, dateTime);
+        
+        [Command("startSerwer")]
+        [Summary("Alias dla `AF!startServer`.")]
+        [ContextDMOrChannel]
+        public Task StartSerwer(string modsetName, DateTime? dateTime) => StartServer(modsetName, dateTime);
+        
+        [Command("serverStart")]
+        [Summary("Alias dla `AF!startServer`.")]
+        [ContextDMOrChannel]
+        public Task ServerStart(string modsetName, DateTime? dateTime) => StartServer(modsetName, dateTime);
     }
 }


### PR DESCRIPTION
2 new added aliases are:
- `startSerwer`
- `serverStart` (`serverStatus` command suggests this command should exist)